### PR TITLE
Add docker-compose development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /flight-fetcher
 *.hcl
 !deploy/*.hcl
+!config.example.hcl
 .env
 coverage.out
 dist/

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,14 @@ lint: ## Run Go linter
 test: ## Run Go tests with coverage
 	go test -race -cover ./...
 
-run: ## Run locally (requires config.hcl)
-	go run ./cmd/server -config config.hcl
+run: ## Build and run the full stack via docker-compose (requires config.hcl)
+	docker compose up --build
+
+stop: ## Stop the docker-compose stack
+	docker compose down
+
+clean: ## Stop the stack and remove volumes
+	docker compose down -v
 
 # -------------------------------------------------------------------------
 # DOCKER
@@ -70,5 +76,5 @@ push: ## Build and push multi-arch images to registry
 	  --output type=image,push=true \
 	  .
 
-.PHONY: help generate migration vet govulncheck lint test run push
+.PHONY: help generate migration vet govulncheck lint test run stop clean push
 .DEFAULT_GOAL := help

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ A Go service that polls the OpenSky Network API for aircraft within a configurab
     +-----------+  +------------+
 ```
 
+## Quick Start
+
+```bash
+cp config.example.hcl config.hcl
+# Edit config.hcl with your OpenSky credentials
+# Register at https://opensky-network.org for free API access
+docker compose up --build
+```
+
+The service starts polling OpenSky for aircraft near the configured location, enriches metadata via HexDB.io, and stores results in Postgres and Redis.
+
 ## Configuration
 
 Configuration is loaded from an HCL file. Secrets are templated in by Vault at deploy time.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -49,7 +49,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	oskyClient := opensky.NewClient(cfg.OpenSky.Username, cfg.OpenSky.Password)
+	oskyClient := opensky.NewClient(cfg.OpenSky.ID, cfg.OpenSky.Secret)
 	hexdbClient := hexdb.NewClient()
 
 	redisStore := store.NewRedisStore(cfg.Redis.Addr, cfg.Redis.Password, cfg.Redis.DB)

--- a/config.example.hcl
+++ b/config.example.hcl
@@ -1,0 +1,29 @@
+# -------------------------------------------------------------------------------
+# Flight Fetcher - Example Configuration
+#
+# Project: Flight Fetcher / Author: Alex Freidah
+#
+# Copy this file to config.hcl and fill in your OpenSky Network credentials.
+# Register at https://opensky-network.org to get free API access.
+# -------------------------------------------------------------------------------
+
+location {
+  lat       = 34.0928
+  lon       = -118.3287
+  radius_km = 50.0
+}
+
+opensky {
+  id     = "YOUR_CLIENT_ID"
+  secret = "YOUR_CLIENT_SECRET"
+}
+
+poll_interval = "20s"
+
+redis {
+  addr = "redis:6379"
+}
+
+postgres {
+  dsn = "postgres://flight_fetcher:flight_fetcher@postgres:5432/flight_fetcher?sslmode=disable"
+}

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -7,7 +7,7 @@
 # binary. Configuration is mounted at runtime by Nomad.
 # -------------------------------------------------------------------------------
 
-FROM golang:1.23-alpine AS build
+FROM golang:1.26-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,61 @@
+# -------------------------------------------------------------------------------
+# Flight Fetcher - Development Environment
+#
+# Project: Flight Fetcher / Author: Alex Freidah
+#
+# Runs the full stack locally: Postgres, Redis, and the flight-fetcher service.
+# Copy config.example.hcl to config.hcl and fill in OpenSky credentials before
+# starting: docker compose up --build
+# -------------------------------------------------------------------------------
+
+services:
+  # -------------------------------------------------------------------------
+  # POSTGRES
+  # -------------------------------------------------------------------------
+  postgres:
+    image: postgres:16-alpine
+    ports:
+      - "15432:5432"
+    environment:
+      POSTGRES_USER: flight_fetcher
+      POSTGRES_PASSWORD: flight_fetcher
+      POSTGRES_DB: flight_fetcher
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U flight_fetcher"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  # -------------------------------------------------------------------------
+  # REDIS
+  # -------------------------------------------------------------------------
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "16379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  # -------------------------------------------------------------------------
+  # FLIGHT FETCHER
+  # -------------------------------------------------------------------------
+  flight-fetcher:
+    build:
+      context: .
+      dockerfile: deploy/Dockerfile
+    volumes:
+      - ./config.hcl:/etc/flight-fetcher/config.hcl:ro
+    command: ["-config", "/etc/flight-fetcher/config.hcl"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+volumes:
+  pgdata:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,8 +38,8 @@ type Location struct {
 
 // OpenSkyConfig holds credentials for the OpenSky Network API.
 type OpenSkyConfig struct {
-	Username string `hcl:"username"`
-	Password string `hcl:"password"`
+	ID     string `hcl:"id"`
+	Secret string `hcl:"secret"`
 }
 
 // RedisConfig holds connection parameters for Redis.

--- a/internal/opensky/client.go
+++ b/internal/opensky/client.go
@@ -4,7 +4,7 @@
 // Project: Flight Fetcher / Author: Alex Freidah
 //
 // HTTP client for the OpenSky Network REST API. Queries aircraft state vectors
-// within a geographic bounding box using basic authentication. Parses the raw
+// within a geographic bounding box using API client credentials. Parses the raw
 // heterogeneous JSON arrays into typed StateVector structs.
 // -------------------------------------------------------------------------------
 
@@ -26,8 +26,8 @@ import (
 // Client communicates with the OpenSky Network API.
 type Client struct {
 	httpClient *http.Client
-	username   string
-	password   string
+	clientID   string
+	clientSecret string
 	baseURL    string
 }
 
@@ -35,13 +35,13 @@ type Client struct {
 // PUBLIC API
 // -------------------------------------------------------------------------
 
-// NewClient creates an OpenSky API client with the given credentials.
-func NewClient(username, password string) *Client {
+// NewClient creates an OpenSky API client with the given API client credentials.
+func NewClient(clientID, clientSecret string) *Client {
 	return &Client{
-		httpClient: &http.Client{},
-		username:   username,
-		password:   password,
-		baseURL:    "https://opensky-network.org/api",
+		httpClient:   &http.Client{},
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		baseURL:      "https://opensky-network.org/api",
 	}
 }
 
@@ -55,8 +55,8 @@ func (c *Client) GetStates(ctx context.Context, bbox geo.BBox) (*StatesResponse,
 	if err != nil {
 		return nil, fmt.Errorf("creating request: %w", err)
 	}
-	if c.username != "" {
-		req.SetBasicAuth(c.username, c.password)
+	if c.clientID != "" {
+		req.SetBasicAuth(c.clientID, c.clientSecret)
 	}
 
 	resp, err := c.httpClient.Do(req)


### PR DESCRIPTION
## Summary

- Add `docker-compose.yml` with Postgres 16, Redis 7, and flight-fetcher container
- Add `config.example.hcl` with Hollywood, LA coordinates and placeholder creds
- Update Makefile: `make run` builds and starts the full stack, `make stop` and `make clean` for teardown
- Update OpenSky auth from username/password to API client id/secret
- Fix Dockerfile Go version (1.23 -> 1.26)
- Add quick-start section to README

Closes #6
Closes #4

## Test plan

- [x] `make run` builds image and starts all three services
- [x] Migrations apply on startup
- [x] Poller connects to OpenSky, discovers ~30+ aircraft near LAX
- [x] Sightings logged to Postgres, aircraft metadata enriched via HexDB
- [x] Live state stored in Redis with TTL
- [x] `make stop` and `make clean` tear down cleanly