### PR TITLE
Add global emergency squawk monitor with deduplication

### DIFF
--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -54,13 +54,15 @@ type FlightEnricher interface {
 
 // Poller periodically queries a flight source for aircraft near a fixed location.
 type Poller struct {
-	source   FlightSource
-	cache    FlightCache
-	logger   SightingLogger
-	enricher FlightEnricher
-	center   geo.Coord
-	radiusKm float64
-	interval time.Duration
+	source     FlightSource
+	cache      FlightCache
+	logger     SightingLogger
+	enricher   FlightEnricher
+	center     geo.Coord
+	radiusKm   float64
+	interval   time.Duration
+	seenICAO   map[string]bool
+	seenRoutes map[string]bool
 }
 
 // -------------------------------------------------------------------------
@@ -78,13 +80,15 @@ func New(
 	interval time.Duration,
 ) *Poller {
 	return &Poller{
-		source:   source,
-		cache:    cache,
-		logger:   logger,
-		enricher: enr,
-		center:   center,
-		radiusKm: radiusKm,
-		interval: interval,
+		source:     source,
+		cache:      cache,
+		logger:     logger,
+		enricher:   enr,
+		center:     center,
+		radiusKm:   radiusKm,
+		interval:   interval,
+		seenICAO:   make(map[string]bool),
+		seenRoutes: make(map[string]bool),
 	}
 }
 
@@ -144,9 +148,14 @@ func (p *Poller) poll(ctx context.Context) {
 				slog.String("error", err.Error()))
 		}
 
-		p.enricher.Enrich(ctx, sv.ICAO24)
-		if callsign := strings.TrimSpace(sv.Callsign); callsign != "" {
+		if !p.seenICAO[sv.ICAO24] {
+			if p.enricher.Enrich(ctx, sv.ICAO24) {
+				p.seenICAO[sv.ICAO24] = true
+			}
+		}
+		if callsign := strings.TrimSpace(sv.Callsign); callsign != "" && !p.seenRoutes[callsign] {
 			p.enricher.EnrichRoute(ctx, callsign)
+			p.seenRoutes[callsign] = true
 		}
 		count++
 	}

--- a/internal/poller/poller_test.go
+++ b/internal/poller/poller_test.go
@@ -153,6 +153,48 @@ func TestPoll_LoggerError_ContinuesProcessing(t *testing.T) {
 	p.poll(context.Background())
 }
 
+// TestPoll_SkipsEnrichmentOnSecondCycle verifies that already-seen aircraft are not re-enriched.
+func TestPoll_SkipsEnrichmentOnSecondCycle(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	source := NewMockFlightSource(ctrl)
+	cache := NewMockFlightCache(ctrl)
+	logger := NewMockSightingLogger(ctrl)
+	enricher := NewMockFlightEnricher(ctrl)
+
+	center := geo.Coord{Lat: 34.0928, Lon: -118.3287}
+
+	resp := &opensky.StatesResponse{
+		Time: 1234,
+		States: []opensky.StateVector{
+			{ICAO24: "abc123", Callsign: "AAL100", Latitude: 34.09, Longitude: -118.33},
+		},
+	}
+
+	source.EXPECT().
+		GetStates(gomock.Any(), gomock.Any()).
+		Return(resp, nil).
+		Times(2)
+	cache.EXPECT().
+		SetFlight(gomock.Any(), gomock.Any()).
+		Return(nil).
+		Times(2)
+	logger.EXPECT().
+		LogSighting(gomock.Any(), "abc123", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).
+		Times(2)
+	enricher.EXPECT().
+		Enrich(gomock.Any(), "abc123").
+		Return(true).
+		Times(1)
+	enricher.EXPECT().
+		EnrichRoute(gomock.Any(), "AAL100").
+		Times(1)
+
+	p := New(source, cache, logger, enricher, center, 50.0, time.Minute)
+	p.poll(context.Background())
+	p.poll(context.Background())
+}
+
 // TestPoll_EmptyResponse verifies that an empty states response completes without errors.
 func TestPoll_EmptyResponse(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/internal/squawk/monitor.go
+++ b/internal/squawk/monitor.go
@@ -56,12 +56,17 @@ type AlertEnricher interface {
 // TYPES
 // -------------------------------------------------------------------------
 
+// alertCooldown is the minimum time between recording duplicate alerts for
+// the same aircraft and squawk code.
+const alertCooldown = 30 * time.Minute
+
 // Monitor polls for global emergency squawk codes on a configurable interval.
 type Monitor struct {
 	source   GlobalFlightSource
 	store    AlertStore
 	enricher AlertEnricher
 	interval time.Duration
+	seen     map[string]time.Time // key: "icao24:squawk", value: last recorded time
 }
 
 // -------------------------------------------------------------------------
@@ -75,6 +80,7 @@ func New(source GlobalFlightSource, store AlertStore, enricher AlertEnricher, in
 		store:    store,
 		enricher: enricher,
 		interval: interval,
+		seen:     make(map[string]time.Time),
 	}
 }
 
@@ -116,9 +122,15 @@ func (m *Monitor) scan(ctx context.Context) {
 		return
 	}
 
+	now := time.Now()
 	count := 0
 	for _, sv := range resp.States {
 		if !emergencySquawks[sv.Squawk] {
+			continue
+		}
+
+		key := sv.ICAO24 + ":" + sv.Squawk
+		if last, ok := m.seen[key]; ok && now.Sub(last) < alertCooldown {
 			continue
 		}
 
@@ -137,12 +149,21 @@ func (m *Monitor) scan(ctx context.Context) {
 				slog.String("error", err.Error()))
 		}
 
+		m.seen[key] = now
+
 		m.enricher.Enrich(ctx, sv.ICAO24)
 		if callsign != "" {
 			m.enricher.EnrichRoute(ctx, callsign)
 		}
 
 		count++
+	}
+
+	// Evict expired entries
+	for key, last := range m.seen {
+		if now.Sub(last) >= alertCooldown {
+			delete(m.seen, key)
+		}
 	}
 
 	slog.InfoContext(ctx, "squawk scan complete",

--- a/internal/squawk/monitor_test.go
+++ b/internal/squawk/monitor_test.go
@@ -199,3 +199,27 @@ func TestScan_EmptyCallsign(t *testing.T) {
 		t.Errorf("len(routes) = %d, want 0 for empty callsign", len(enr.routes))
 	}
 }
+
+// TestScan_DeduplicatesWithinCooldown verifies that the same aircraft+squawk is only recorded once within the cooldown window.
+func TestScan_DeduplicatesWithinCooldown(t *testing.T) {
+	source := &stubSource{resp: &opensky.StatesResponse{
+		Time: 1234,
+		States: []opensky.StateVector{
+			{ICAO24: "a1", Callsign: "UAL123", Squawk: "7700", Latitude: 34.0, Longitude: -118.0},
+		},
+	}}
+	store := &stubAlertStore{}
+	enr := &stubEnricher{}
+
+	m := New(source, store, enr, time.Minute)
+	m.scan(context.Background())
+	m.scan(context.Background())
+	m.scan(context.Background())
+
+	if len(store.alerts) != 1 {
+		t.Errorf("len(alerts) = %d, want 1 (duplicates should be suppressed)", len(store.alerts))
+	}
+	if len(enr.enriched) != 1 {
+		t.Errorf("len(enriched) = %d, want 1", len(enr.enriched))
+	}
+}


### PR DESCRIPTION
## Summary

Closes #17
Closes #20
Closes #21

- New `internal/squawk/` package with a background monitor that polls OpenSky globally on a configurable interval
- Filters for emergency squawk codes: 7500 (hijack), 7600 (radio failure), 7700 (emergency)
- In-memory cooldown (30 min) prevents duplicate alert rows for the same aircraft+squawk
- Poller maintains in-memory seen sets for ICAO24s and callsigns, skipping redundant enrichment queries on subsequent poll cycles
- Detected aircraft are enriched via HexDB + AirLabs and stored in a new `squawk_alerts` Postgres table
- Dashboard displays a "Global Emergency Squawk Alerts" section with 30s refresh
- New `GET /api/squawk-alerts` endpoint returns alerts from the last 24 hours
- Optional `squawk_monitor { interval = "60s" }` config block; no-op when omitted
- Full test coverage including dedup behavior

## Test plan

- [x] `go test -race ./...` passes
- [x] `make lint` clean
- [ ] CI passes (vet, lint, test, govulncheck)